### PR TITLE
Proposed addition for issue #165

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -134,6 +134,8 @@ def create_cli_parser():
                               type=lambda s:[int(i) for i in s.split(",")],
                               help=("Comma-seperated additional port(s) to assume "
                               "are https (e.g. '8018,8028')"))
+    http_options.add_argument('--prepend-https', default=False, action='store_true',
+                              help='Prepend http:\\\\ and https:\\\\ to URLs without either')
 
     resume_options = parser.add_argument_group('Resume Options')
     resume_options.add_argument('--resume', metavar='ew.db',

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -298,11 +298,16 @@ def target_creator(command_line_object):
                 elif line.startswith('vnc://'):
                     vnc.append(line[6:])
                 else:
-                    urls.append(line)
                     if command_line_object.rdp:
                         rdp.append(line)
                     if command_line_object.vnc:
                         vnc.append(line)
+                    if command_line_object.web or command_line_object.headless:
+                        if command_line_object.prepend_https:
+                            urls.append("http://" + line)
+                            urls.append("https://" + line)
+                        else:
+                            urls.append(line)
                 num_urls += 1
 
             return urls, rdp, vnc


### PR DESCRIPTION
adds in --prepend-https option which adds both http:// and https:// to the front of URLs which don't have either in the URL.