### PR TITLE
Add ability to specify hostname in Host header for phantomjs/single mode

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -205,7 +205,7 @@ def create_cli_parser():
         parser.print_help()
         sys.exit()
 
-    if args.vhost_name and not all(args.single, args.headless):
+    if args.vhost_name and not all((args.single, args.headless)):
         print "[*] Error: vhostname can only be used in headless+single mode"
         sys.exit()
     

--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -136,6 +136,7 @@ def create_cli_parser():
                               "are https (e.g. '8018,8028')"))
     http_options.add_argument('--prepend-https', default=False, action='store_true',
                               help='Prepend http:\\\\ and https:\\\\ to URLs without either')
+    http_options.add_argument('--vhost-name', default=None,metavar='hostname', help='Hostname to use in Host header (headless + single mode only)')
 
     resume_options = parser.add_argument_group('Resume Options')
     resume_options.add_argument('--resume', metavar='ew.db',
@@ -200,6 +201,10 @@ def create_cli_parser():
     if all((args.web, args.headless)):
         print "[*] Error: Choose either web or headless"
         parser.print_help()
+        sys.exit()
+
+    if not all((args.vhost_name, args.single, args.headless)):
+        print "[*] Error: hostname can only be used in headless+single mode"
         sys.exit()
 
     if args.resume:

--- a/modules/phantomjs_module.py
+++ b/modules/phantomjs_module.py
@@ -32,6 +32,10 @@ def create_driver(cli_parsed, user_agent=None):
         webdriver: PhantomJS Webdriver
     """
     capabilities = DesiredCapabilities.PHANTOMJS
+
+    if cli_parsed.vhost_name:
+        capabilities['phantomjs.page.customHeaders.Host'] = cli_parsed.vhost_name
+
     service_args = []
     phantomjs_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), '..', 'bin', 'phantomjs')


### PR DESCRIPTION
Hi,

in cases where one is trying to run eyewitness against an IP that serves multiple virtual hosts, being able to set the Host header is useful to request a specific virtual host. While normally you'd expect DNS to be set up correctly, where this is not the case, one needs to run against the IP and specify a Host explicitly. This PR allows that in single+headless mode, as phantomjs makes it straightforward, so submitting this for inclusion