### PR TITLE
Fix for Geckodriver

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[11.03.2016]
+    Released..: 2.21
+    Fixed.....: Latest Firefox on Kali requires geckodriver.  This is now placed in /usr/sbin during the setup process
+
 [07.17.2016]
     Released..: 2.2
     Fixed.....: Replaced feature which allows you to specify extra ports to look for for HTTP or HTTPS services when parsing XML.

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -51,8 +51,16 @@ case ${osinfo} in
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} == 'x86_64' ]; then
       wget -O phantomjs https://www.christophertruncer.com/InstallMe/kali2phantomjs
+      wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
+      tar -xvf geckodriver-v0.11.1-linux64.tar.gz
+      rm geckodriver-v0.11.1-linux64.tar.gz
+      mv geckodriver /usr/sbin
     else
       wget -O phantomjs https://www.christophertruncer.com/InstallMe/phantom32kali2
+      wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux32.tar.gz
+      tar -xvf geckodriver-v0.11.1-linux32.tar.gz
+      rm geckodriver-v0.11.1-linux64.tar.gz
+      mv geckodriver /usr/sbin
     fi
     chmod +x phantomjs
     cd ..


### PR DESCRIPTION
This fixes issue #220 and places the geckodriver in /usr/sbin during the setup process.  In testing, this only seems to impact Kali.