### PR TITLE
Added in ability to specify max retries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[11.16.2016]
+    Released..: 2.3
+    Added.....: Users can now specify how many times EyeWitness should retry connecting to websites after they've hit the timeout limit.
+
 [11.03.2016]
     Released..: 2.21
     Fixed.....: Latest Firefox on Kali requires geckodriver.  This is now placed in /usr/sbin during the setup process

--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -93,6 +93,9 @@ def create_cli_parser():
     timing_options.add_argument('--threads', metavar='# of Threads', default=10,
                                 type=int, help='Number of threads to use while using\
                                 file based input')
+    timing_options.add_argument('--max-retries', default=1, metavar='Max retries on \
+                                a timeout'.replace('    ', ''), type=int,
+                                help='Max retries on timeouts')
 
     report_options = parser.add_argument_group('Report Output Options')
     report_options.add_argument('-d', metavar='Directory Name',


### PR DESCRIPTION
This adds in a feature from issue #225.  This pull request allows users to specify the max amount of retries for each website that hit the timeout limit while EyeWitness was trying to screenshot it.

This only applied to websites (not RDP or VNC).