### PR TITLE
remove hard-coded paths

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -317,7 +317,12 @@ def worker_thread(cli_parsed, targets, lock, counter, user_agent=None):
         create_driver = selenium_module.create_driver
         capture_host = selenium_module.capture_host
     elif cli_parsed.headless:
-        if not os.path.isfile('./bin/phantomjs'):
+        if not os.path.isfile(
+            os.path.join(
+                os.path.dirname(
+                    os.path.realpath(__file__)
+                ), 'bin', 'phantomjs')
+        ):
             print(" [*] Error: You are missing your phantomjs binary!")
             print(" [*] Please run the setup script!")
             sys.exit(0)

--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -254,7 +254,10 @@ def single_mode(cli_parsed):
             display.start()
     elif cli_parsed.headless:
         if not os.path.isfile(
-            os.path.join(os.path.realpath(__file__), 'bin', 'phantomjs')
+            os.path.join(
+                os.path.dirname(
+                    os.path.realpath(__file__)
+                ), 'bin', 'phantomjs')
         ):
             print(" [*] Error: You are missing your phantomjs binary!")
             print(" [*] Please run the setup script!")

--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -253,7 +253,9 @@ def single_mode(cli_parsed):
             display = Display(visible=0, size=(1920, 1080))
             display.start()
     elif cli_parsed.headless:
-        if not os.path.isfile('./bin/phantomjs'):
+        if not os.path.isfile(
+            os.path.join(os.path.realpath(__file__), 'bin', 'phantomjs')
+        ):
             print(" [*] Error: You are missing your phantomjs binary!")
             print(" [*] Please run the setup script!")
             sys.exit(0)

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -26,6 +26,10 @@ if [[ `grep "Kali GNU/Linux.*\(2\|Rolling\)" /etc/issue` ]]; then
   osinfo="Kali2"
 fi
 
+# make sure we run from this directory
+pushd . > /dev/null
+cd "$(dirname "$0")"
+
 # OS Specific Installation Statement
 case ${osinfo} in
   # Kali 2 dependency Install
@@ -202,6 +206,7 @@ case ${osinfo} in
       rpm -ivh ${eplpkg}
     else
       echo '[!] User Aborted EyeWitness Installation.'
+      popd > /dev/null
       exit 1
     fi
     echo '[*] Installing CentOS Dependencies'
@@ -248,9 +253,11 @@ case ${osinfo} in
   *)
     echo "[Error]: ${osinfo} is not supported by this setup script."
     echo
+    popd > /dev/null
     exit 1
 esac
 
 # Finish Message
+popd > /dev/null
 echo '[*] Setup script completed successfully, enjoy EyeWitness! :)'
 echo

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -27,8 +27,7 @@ if [[ `grep "Kali GNU/Linux.*\(2\|Rolling\)" /etc/issue` ]]; then
 fi
 
 # make sure we run from this directory
-pushd . > /dev/null
-cd "$(dirname "$0")"
+pushd . > /dev/null && cd "$(dirname "$0")"
 
 # OS Specific Installation Statement
 case ${osinfo} in


### PR DESCRIPTION
In my changes I've removed the hard-coded path check for "./bin/phantomjs" so EyeWitness can be executed from anywhere. 
Also, the setup script was complaining of a non-existing directory "../bin" when running it as `sudo ./setup/setup.sh`. In my change I save the current directory, `cd` into the directory where the script is living and run it from there. 