### PR TITLE
Improve osinfo resolution to use standard lsb_release

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -22,7 +22,7 @@ if [ "${userid}" != '0' ]; then
   exit 1
 fi
 #Support for kali 2 and kali rolling
-if [[ `grep "Kali GNU/Linux.*\(2\|Rolling\)" /etc/issue` ]]; then
+if [[ `(lbs_release -sd || grep ^PRETTY_NAME /etc/os-release) 2>/dev/null | grep "Kali GNU/Linux.*\(2\|Rolling\)"` ]]; then
   osinfo="Kali2"
 fi
 


### PR DESCRIPTION
Currently the setup script uses `/etc/issue` to check the OS version for Kali indicators. This isn't very robust and breaks if `/etc/issue` is customized. Using `lsb_release` to perform this check is more reliable, and if that fails falling back to `/etc/os-release` works as well. This could be further improved by removing the `if` block entirely and modifying the `case` block to use expected outputs of `lsb_release`.