### PR TITLE
fixed path of phantomjs binary

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -127,7 +127,7 @@ case ${osinfo} in
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
       tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
       cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-x86_64
       rm phantomjs-2.1.1-linux-x86_64.tar.bz2
@@ -140,7 +140,7 @@ case ${osinfo} in
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
       tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
       cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-i686
       rm phantomjs-2.1.1-linux-i686.tar.bz2
@@ -179,7 +179,7 @@ case ${osinfo} in
       mv geckodriver /usr/sbin
       tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
       cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-x86_64
       rm phantomjs-2.1.1-linux-x86_64.tar.bz2
@@ -191,7 +191,7 @@ case ${osinfo} in
       mv geckodriver /usr/sbin
       tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
       cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-i686
       rm phantomjs-2.1.1-linux-i686.tar.bz2
@@ -234,7 +234,7 @@ case ${osinfo} in
       wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
       tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
       cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-x86_64
       rm phantomjs-2.1.1-linux-x86_64.tar.bz2
@@ -242,7 +242,7 @@ case ${osinfo} in
       wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2
       tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
       cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
+      mv phantomjs ../../bin/
       cd ../..
       rm -rf phantomjs-2.1.1-linux-i686
       rm phantomjs-2.1.1-linux-i686.tar.bz2


### PR DESCRIPTION
Current implementation installs the phantomjs binary to the EyeWitness root directory. This PR corrects that by ensuring it's thrown into bin/.