### PR TITLE
Small fix for the logging of the hostname

### DIFF
--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -196,7 +196,7 @@ def sort_data_and_write(cli_parsed, data):
             csv_request_data += "80,"
         elif url.scheme == 'https':
             csv_request_data += "443,"
-        csv_request_data += url.netloc + ","
+        csv_request_data += url.hostname + ","
         if json_request._error_state == None:
             csv_request_data += "Successful,"
         else:


### PR DESCRIPTION
I personally think it's better to save in the field domain the domain without the port if it's specified.

Before, the domain (if set with a port in the input list) was looking like this (for "google.com:8000"):

`Protocol,Port,Domain,Request Status,Screenshot Path, Source Path
http,8000,google.com:8000,ConnRefuse,/tmp/output/screens/http.google.com.8000.png,/tmp/output/source/http.google.com.8000.txt`

With this small change, the port is stripped out of the "domain" column:

`Protocol,Port,Domain,Request Status,Screenshot Path, Source Path
http,8000,google.com,ConnRefuse,/tmp/output/screens/http.google.com.8000.png,/tmp/output/source/http.google.com.8000.txt`