### PR TITLE
Exceptions for unusual Unicode characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+[03.11.2018]
+	Modified..: Report output now includes Requests.csv which contains the status of the web requests made in the EyeWitness run
+
 [05.27.2017]
     Modified..: DB checks for user agent source code values to not be None prior to running source code comparison
 

--- a/modules/objects.py
+++ b/modules/objects.py
@@ -296,7 +296,7 @@ class HTTPTableObject(object):
         return html
 
     def sanitize(self, html):
-        return cgi.escape(html.decode('utf-8', errors='backslashreplace'), quote=True)
+        return cgi.escape(html.decode('utf-8', errors='replace'), quote=True)
 
     def add_ua_data(self, uaobject):
         difference = abs(len(self.source_code) - len(uaobject.source_code))

--- a/modules/objects.py
+++ b/modules/objects.py
@@ -227,8 +227,12 @@ class HTTPTableObject(object):
                 self.remote_system)
 
         if self.default_creds is not None:
-            html += "<br><b>Default credentials:</b> {0}<br>".format(
-                self.sanitize(self.default_creds))
+            try:
+                html += "<br><b>Default credentials:</b> {0}<br>".format(
+                    self.sanitize(self.default_creds))
+            except UnicodeEncodeError:
+                html += u"<br><b>Default credentials:</b> {0}<br>".format(
+                    self.sanitize(self.default_creds))
 
         if self.error_state is None:
             try:
@@ -237,11 +241,17 @@ class HTTPTableObject(object):
             except UnicodeDecodeError:
                 html += "\n<br><b> Page Title:</b>{0}\n".format(
                     'Unable to Display')
+            except UnicodeEncodeError:
+                html += u"\n<br><b> Page Title:</b>{0}\n".format(
+                    self.sanitize(self.page_title))
 
             for key, value in self.headers.items():
-                html += '<br><b> {0}:</b> {1}\n'.format(
-                    self.sanitize(key), self.sanitize(value))
-
+                try:
+                    html += '<br><b> {0}:</b> {1}\n'.format(
+                        self.sanitize(key), self.sanitize(value))
+                except UnicodeEncodeError:
+                    html += u'<br><b> {0}:</b> {1}\n'.format(
+                        self.sanitize(key), self.sanitize(value))
         if self.blank:
             html += ("""<br></td>
             <td><div style=\"display: inline-block; width: 850px;\">Page Blank\
@@ -384,19 +394,30 @@ class UAObject(HTTPTableObject):
                 self.remote_system)
 
         if self.default_creds is not None:
-            html += "<br><b>Default credentials:</b> {0}<br>".format(
-                self.sanitize(self.default_creds))
-
+            try:
+                html += "<br><b>Default credentials:</b> {0}<br>".format(
+                    self.sanitize(self.default_creds))
+            except UnicodeEncodeError:
+                html += u"<br><b>Default credentials:</b> {0}<br>".format(
+		    self.sanitize(self.default_creds))
+                
         try:
             html += "\n<br><b> Page Title: </b>{0}\n".format(
                 self.sanitize(self.page_title))
         except UnicodeDecodeError:
             html += "\n<br><b> Page Title:</b>{0}\n".format(
                 'Unable to Display')
+        except UnicodeEncodeError:
+                html += u'<br><b> Page Title: </b>{0}\n'.format(
+                    self.sanitize(self.page_title))
 
         for key, value in self.headers.items():
-            html += '<br><b> {0}:</b> {1}\n'.format(
-                self.sanitize(key), self.sanitize(value))
+            try: 
+                html += '<br><b> {0}:</b> {1}\n'.format(
+                    self.sanitize(key), self.sanitize(value))
+            except UnicodeEncodeError:
+                html += u'<br><b> {0}:</b> {1}\n'.format(
+                    self.sanitize(key), self.sanitize(value))
 
         if self.blank:
             html += ("""<br></td>

--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -490,7 +490,13 @@ def search_report(cli_parsed, data, search_term):
         if len(pages) == 0:
             return
         with open(os.path.join(cli_parsed.d, 'search.html'), 'a') as f:
-            f.write(pages[0].encode('utf-8'))
+            try:
+                f.write(pages[0])
+            except UnicodeEncodeError:
+                f.write(pages[0].encode('utf-8'))
         for i in range(2, len(pages) + 1):
             with open(os.path.join(cli_parsed.d, 'search_page{0}.html'.format(str(i))), 'w') as f:
-                f.write(pages[i - 1].encode('utf-8'))
+                try:
+                    f.write(pages[i - 1])
+                except UnicodeEncodeError:
+                    f.write(pages[i - 1].encode('utf-8'))

--- a/modules/reporting.py
+++ b/modules/reporting.py
@@ -490,7 +490,7 @@ def search_report(cli_parsed, data, search_term):
         if len(pages) == 0:
             return
         with open(os.path.join(cli_parsed.d, 'search.html'), 'a') as f:
-            f.write(pages[0])
+            f.write(pages[0].encode('utf-8'))
         for i in range(2, len(pages) + 1):
             with open(os.path.join(cli_parsed.d, 'search_page{0}.html'.format(str(i))), 'w') as f:
-                f.write(pages[i - 1])
+                f.write(pages[i - 1].encode('utf-8'))


### PR DESCRIPTION
This pull request's goal is to make sure that Unicode encoding errors in `objects.py` and `reporting.py` are caught and dealt with. 

---

For any html doc that has weird Unicode characters, you can decode it fine, but after the sanitation process (exhibited in `objects.py`) you cannot store it in a variable as a non-Unicode string. In fixing this problem a new problem arose, you couldn't write non-Unicode encoded strings to files. This is fixed by excepting the `UnicodeEncodeError` and writing instead as an encoded string.